### PR TITLE
[#20] wip: 날짜 클릭시 하단에 내역 표시

### DIFF
--- a/client/src/components/Calendar/Calendar.scss
+++ b/client/src/components/Calendar/Calendar.scss
@@ -51,6 +51,11 @@ $week-height: 48px;
           border-right: 1px solid $line;
           border-bottom: 1px solid $line;
 
+          &:hover {
+            background-color: $background;
+            cursor: pointer;
+          }
+
           &:nth-child(7) {
             border-right: none;
           }
@@ -84,7 +89,7 @@ $week-height: 48px;
           }
 
           &.today {
-            background-color: $background;
+            // background-color: $background;
 
             & .week__day__date {
               color: $title-active;

--- a/client/src/components/CalendarAccountList/CalendarAccountList.scss
+++ b/client/src/components/CalendarAccountList/CalendarAccountList.scss
@@ -1,0 +1,7 @@
+.stat-account {
+  &__no-data {
+    @include display(small);
+    color: $placeholder;
+    text-align: center;
+  }
+}

--- a/client/src/components/CalendarAccountList/CalendarAccountList.ts
+++ b/client/src/components/CalendarAccountList/CalendarAccountList.ts
@@ -1,0 +1,54 @@
+import { dayToKorean } from '../../utils/chore';
+
+const CalendarAccountList = (
+  accountList,
+  currentYear: number,
+  currentMonth: number,
+  currentDate: number,
+) => {
+  const accountsByDate = accountList.filter(
+    (account) => parseInt(account.timestamp.split('-')[2]) === currentDate,
+  );
+
+  if (!accountsByDate.length)
+    return `
+      <div class="stat-account">
+        <div class="stat-account__no-data">해당 날짜에 내역이 없습니다</div>
+      </div>`;
+
+  const fullDate = new Date(currentYear, currentMonth - 1, currentDate);
+
+  const dateString = `${currentMonth}월 ${currentDate}일 <span class="weekday">${
+    dayToKorean[fullDate.getDay()]
+  }</span>`;
+
+  const markup = `
+      <div class="stat-account__header">
+        <span>${dateString}</span>
+      </div>
+      <ul class="stat-account__list">
+        ${accountsByDate.map((account) => StatAccountItem(account)).join('')}
+      </ul>
+    `;
+
+  return `<div class="stat-account">${markup}</div>`;
+};
+
+const StatAccountItem = ({
+  category_color,
+  category_name,
+  content,
+  payment_name,
+  amount,
+}) => {
+  amount && (amount = parseInt(amount, 10).toLocaleString('ko-KR') + '원');
+  return /*html*/ `
+    <li class="stat-account__item">
+      <button class="stat-account__item__category" style="background:${category_color}">${category_name}</button>
+      <div class="stat-account__item__content">${content}</div>
+      <div class="stat-account__item__payment">${payment_name}</div>
+      <div class="stat-account__item__amount">${amount}</div>
+    </li>`;
+};
+
+export default CalendarAccountList;

--- a/client/src/containers/CalendarContainer.ts
+++ b/client/src/containers/CalendarContainer.ts
@@ -1,4 +1,5 @@
 import Calendar from '../components/Calendar/Calendar';
+import CalendarAccountList from '../components/CalendarAccountList/CalendarAccountList';
 import dateStore from '../store/date';
 import accountStore from '../store/account';
 import View from '../utils/View';
@@ -31,8 +32,42 @@ class CalendarContainer extends View {
 
   componentDidMount = () => {
     accountStore.subscribe(this.getGlobalState);
+    accountStore.subscribe(this.clearAccounts);
   };
 
-  addEventHandler = () => {};
+  addEventHandler = () => {
+    this.$target.addEventListener('click', this.showAccounts);
+  };
+
+  showAccounts = (e: Event) => {
+    const $target = e.target as HTMLElement;
+    if (!$target.closest('.week__day')) return;
+
+    const $date = $target
+      .closest('.week__day')
+      .querySelector('.week__day__date') as HTMLElement;
+    if (!$date) return;
+
+    this.clearAccounts();
+
+    const { year, month } = this.state.date;
+    this.$target.insertAdjacentHTML(
+      'beforeend',
+      CalendarAccountList(
+        this.state.account,
+        year,
+        month,
+        parseInt($date.dataset.date),
+      ),
+    );
+
+    this.$target
+      .querySelector('.stat-account')
+      .scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  clearAccounts = () => {
+    document.querySelector('.stat-account')?.remove();
+  };
 }
 export default CalendarContainer;

--- a/client/src/public/styles/index.scss
+++ b/client/src/public/styles/index.scss
@@ -37,3 +37,4 @@ button {
 @import './error.scss';
 @import '../../components/LineChart/LineChart.scss';
 @import '../../components/StatAccountList/StatAccountList.scss';
+@import '../../components/CalendarAccountList/CalendarAccountList.scss';


### PR DESCRIPTION
## 요약
- 하단에 내역 표시 / 없을 경우 처리
- 날짜 호버 색상, 커서 포인터
- 통계 탭에서 썼던 내역 컴포넌트 스타일 재활용
- (리팩토링) 컴포넌트 자체를 재사용할 수 있게 만들면 좋을 듯

## 관련 이슈
- #20 
