### PR TITLE
[#20] bug: 결제수단 없을때 '수입'으로 처리

### DIFF
--- a/client/src/components/CalendarAccountList/CalendarAccountList.ts
+++ b/client/src/components/CalendarAccountList/CalendarAccountList.ts
@@ -46,8 +46,10 @@ const StatAccountItem = ({
     <li class="stat-account__item">
       <button class="stat-account__item__category" style="background:${category_color}">${category_name}</button>
       <div class="stat-account__item__content">${content}</div>
-      <div class="stat-account__item__payment">${payment_name}</div>
-      <div class="stat-account__item__amount">${amount}</div>
+      <div class="stat-account__item__payment">${payment_name || '수입'}</div>
+      <div class="stat-account__item__amount">${
+        payment_name ? '-' : '+'
+      }${amount}</div>
     </li>`;
 };
 


### PR DESCRIPTION
## 요약
- 결제수단 없을 때 '수입'으로 처리
- +, - 처리

## 관련 이슈
- #20 